### PR TITLE
Update dependencies to match upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,27 +10,25 @@ source:
   sha256: 633ad6b70e390ea335de8689652a5d6c21a323b79ed19519c2f392451088487f
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.8
   run:
-    - python >=3.6
+    - python >=3.8
     - nltk
     - numpy
     - scikit-learn
     - scipy
     - tqdm
-    - pytorch >=1.6.0
-    - torchvision
-    - sentencepiece
-    - tokenizers >=0.10.3
-    - transformers >=4.6.0,<5.0.0
-    - huggingface_hub >=0.8.1
+    - pytorch >=1.11.0
+    - transformers >=4.34.0,<5.0.0
+    - huggingface_hub >=0.15.1
+    - pillow
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

Some notes regarding the transformers dependency:
* sentence-transformers >= 2.4.0 uses `transformers.utils.import_utils.is_nltk_available` which exists since transformers = 4.34.0.
* In the sentence-transformers requirements.txt file, this was changed: https://github.com/UKPLab/sentence-transformers/blob/d105ec879b978ae078aeca0dd7bef1c48d3fd893/requirements.txt
* My PR for changing it in setup.py as well: https://github.com/UKPLab/sentence-transformers/pull/2589

Regarding the other dependencies:
* Python requirement was increased to 3.8 in sentence-transformers 2.3.0 https://github.com/UKPLab/sentence-transformers/pull/2375
* updated pytorch and huggingface_hub to versions matching setup.py
* torchvision and sentencepiece are no longer referenced in the codebase, so I removed them here. pillow replaces torchvision
* nltk is now an optional dependency but as I understand, these should be treated as regular dependencies in packages on conda-forge